### PR TITLE
Update lilypad_module.json.tmpl

### DIFF
--- a/lilypad_module.json.tmpl
+++ b/lilypad_module.json.tmpl
@@ -37,7 +37,7 @@
       },
       "Resources": {
         "CPU": "1",
-        "Memory": "4000"
+        "Memory": "8000"
       },
       "Timeout": 600,
       "Wasm": {


### PR DESCRIPTION
Bacalhau requires at least  4mb of ram. This fixes the bacalhau error within a RP